### PR TITLE
check if fleetmember is in station

### DIFF
--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -459,7 +459,7 @@ objectdef obj_Hauler
 		}
 		else
 		{
-			if ${FleetMembers.Peek(exists)} && ${Local[${FleetMembers.Peek.Name}](exists)}
+			if ${FleetMembers.Peek(exists)} && ${Local[${FleetMembers.Peek.Name}](exists)} && !${Character["CharID = ${FleetMembers.Peek.CharID}"].InStation}
 			{
 				call This.WarpToFleetMemberAndLoot ${FleetMembers.Peek.CharID}
 			}


### PR DESCRIPTION
prevents a spam of unable to warp to player. there's probably a better way to get to the InStation member, but I haven't found it yet