### PR TITLE
fix warp spam after final pickup

### DIFF
--- a/Branches/Stable/Behaviors/obj_Hauler.iss
+++ b/Branches/Stable/Behaviors/obj_Hauler.iss
@@ -465,6 +465,17 @@ objectdef obj_Hauler
 			}
 			FleetMembers:Dequeue
 		}
+		
+		if !${FleetMembers.Peek(exists)}
+		{
+			call Safespots.WarpTo
+			wait 20
+			do
+			{
+				wait 5
+			}
+			while ${Me.ToEntity.Mode} != 2
+		}
 	}
 	
 /*


### PR DESCRIPTION
since BuildFleetMemberList is called at the beginning of each pulse, the warp to safe spot before beginning the next haul cycle was being interrupted several times until the jetcan was out of range. i need to test further with a hardstop mid-warp.