### PR TITLE
Fix for docking loop in fleeing

### DIFF
--- a/Branches/Stable/core/obj_Station.iss
+++ b/Branches/Stable/core/obj_Station.iss
@@ -110,7 +110,7 @@ objectdef obj_Station
 					Counter:Set[0]
 				}
 			}
-			while !${This.DockedAtStation[${StationID}]}
+			while !${This.DockedAtStation[${StationID}]} && ${Navigator.Busy}
 		}
 		elseif ${Safespots.Count} > 0
 		{


### PR DESCRIPTION
This will fix the docking loop but sometimes seen if it takes longer than 60 seconds to dock.