### PR TITLE
Adding the ability to compress ore while

### DIFF
--- a/Branches/Stable/Behaviors/obj_Miner.iss
+++ b/Branches/Stable/Behaviors/obj_Miner.iss
@@ -794,6 +794,13 @@ objectdef obj_Miner
 			StopCompressing:Set[FALSE]
 		}
 
+		; lets try to compress since solo compression is active
+		if (${Config.Miner.SoloCompressOreMode} && ${Ship.OreHoldHalfFull})
+		{
+			Logger:Log["Debug: Try To Compress"]
+			call Compress.CheckForCompression
+		}
+
 		;	If we're in a station there's not going to be any mining going on.  This should clear itself up if it ever happens.
 		if ${Me.InStation} != FALSE
 		{

--- a/Branches/Stable/core/obj_Configuration.iss
+++ b/Branches/Stable/core/obj_Configuration.iss
@@ -620,6 +620,16 @@ objectdef obj_Configuration_Miner
 		This.MinerRef:AddSetting[Compress Ore Mode, ${value}]
 	}
 
+	member:bool SoloCompressOreMode()
+	{
+		return ${This.MinerRef.FindSetting[Solo Compress Ore Mode, FALSE]}
+	}
+
+	method SetSoloCompressOreMode(bool value)
+	{
+		This.MinerRef:AddSetting[Solo Compress Ore Mode, ${value}]
+	}
+
 	; Deprecated 2020-11-222
 	member:bool OrcaMode()
 	{

--- a/Branches/Stable/interface/EVEBot.xml
+++ b/Branches/Stable/interface/EVEBot.xml
@@ -715,6 +715,23 @@
 								Script[EVEBot].VariableScope.Config.Miner:SetCompressOreMode[${This.Checked}]
 							</OnLeftClick>
 						</checkbox>
+						<checkbox name='cbSoloCompressOreMode'>
+							<X>300</X>
+							<Y>190</Y>
+							<Height>20</Height>
+							<Width>100</Width>
+							<Text>Solo Compress Ore</Text>
+							<AutoTooltip>When this is checked, someone not running evebot is running compression</AutoTooltip>
+							<OnLoad>
+								if ${Script[EVEBot].VariableScope.Config.Miner.SoloCompressOreMode}
+								{
+								This:SetChecked
+								}
+							</OnLoad>
+							<OnLeftClick>
+								Script[EVEBot].VariableScope.Config.Miner:SetSoloCompressOreMode[${This.Checked}]
+							</OnLeftClick>
+						</checkbox>
 						<slider name='AvoidPlayerRange'>
 							<X>10</X>
 							<Y>110</Y>


### PR DESCRIPTION
not running the compression character, this is for if you are in a fleet and the booster that is running compression is not one of your bots. 